### PR TITLE
Update org.json.json to the latest version

### DIFF
--- a/aperture-common/pom.xml
+++ b/aperture-common/pom.xml
@@ -29,7 +29,7 @@
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>
-			<version>20090211</version>
+			<version>20140107</version>
 		</dependency>
 		
 		<dependency>


### PR DESCRIPTION
A dependent project (aperture-tiles) needs a JSONArray.remove function, which didn't exist until the 20131018 version of org.json.json.  I just updated to the latest while I was at it.
