### PR TITLE
MapNodeLayer limits canvas size to 3x viewport

### DIFF
--- a/aperture-client/src/main/javascript/packages/geo/map.js
+++ b/aperture-client/src/main/javascript/packages/geo/map.js
@@ -1094,13 +1094,17 @@ function openLayersMaps() {
 		},
 
 		/**
-		 * Given a location returns its pixel coordinates in container space.
+		 * Given a location returns its pixel coordinates in the viewPort space
 		 */
 		getXY: function(lon,lat) {
-			var px = this._layer.getContentPixelForLonLat(lon,lat);
-			px.x = px.x/this._canvasWidth;
-			px.y = px.y/this._canvasHeight;
-			return px;
+
+			var pt = new OpenLayers.LonLat(lon, lat);
+			
+			// Reproject to map's projection
+			if( this._layer.map.projection != apiProjection ) {
+				pt.transform(apiProjection, this._layer.map.projection);
+			}
+			return this._layer.map.getViewPortPxFromLonLat(pt);
 		},
 
 		getExtent: function() {


### PR DESCRIPTION
Before this change the canvas used by the MapNodeLayer could extend to be millions of pixels wide. While it meant no renders were needed on pan it was not a scalable solution for other renderers (e.g. canvas). 

This change limits the canvas to 3x viewport size and updates the position and contents of the canvas at the end of a map pan.
