### PR TITLE
Fixing maven build for Java 8 without breaking Java 7 build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-javadoc-plugin</artifactId>
                                                 <configuration>
-                                                        <additionalparam>-Xdoclint:syntax,reference</additionalparam>
+                                                        <additionalparam>-Xdoclint:none</additionalparam>
                                                 </configuration>
                                         </plugin>
                                 </plugins>


### PR DESCRIPTION
Selectively disabling the mandatory doclint pass which was added to JDK 8+. Must be done as a profile since the additional parameter in question breaks Java 7 builds because it is unrecognized.
